### PR TITLE
Basic Cleanup and Scrape Optimizations

### DIFF
--- a/incoming/collectd.go
+++ b/incoming/collectd.go
@@ -130,9 +130,9 @@ func (c Collectd) GetMetricDesc(index int) string {
 
 //GetMetricName  ..
 func (c Collectd) GetMetricName(index int) string {
-	name := "service_assurance_collectd_" + c.Plugin + "_" + c.Type
+	name := "sa_collectd_" + c.Plugin + "_" + c.Type
 	if c.Plugin == c.Type {
-		name = "service_assurance_collectd_" + c.Type
+		name = "sa_collectd_" + c.Type
 	}
 
 	if dsname := c.DSName(index); dsname != "value" {

--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func usage() {
 func main() {
 	// set flags for parsing options
 	flag.Usage = usage
+	fIncludeStats := flag.Bool("cpustats", false, "Include cpu usage info in http requests (degrades performance)")
 	fExporterhost := flag.String("mhost", "localhost", "Metrics url for Prometheus to export. ")
 	fExporterport := flag.Int("mport", 8081, "Metrics port for Prometheus to export (http://localhost:<port>/metrics) ")
 	fAmqpurl := flag.String("amqpurl", "", "AMQP1.0 listener example 127.0.0.1:5672/collectd/telemetry")
@@ -98,8 +99,11 @@ func main() {
 
 	myHandler := &cacheHandler{cache: cacheServer.GetCache()}
 
-	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
-	prometheus.Unregister(prometheus.NewGoCollector())
+	if *includeSTats == false {
+		// Including these stats kills performance when Prometheus polls with multiple targets
+		prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
+		prometheus.Unregister(prometheus.NewGoCollector())
+	}
 
 	prometheus.MustRegister(myHandler)
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 var (
 	lastPull = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "service_assurance_collectd_last_pull_timestamp_seconds",
+			Name: "sa_collectd_last_pull_timestamp_seconds",
 			Help: "Unix timestamp of the last received collectd metrics pull in seconds.",
 		},
 	)
@@ -126,7 +126,7 @@ func main() {
 			for hosts := 0; hosts < *fHosts; hosts++ {
 				go func(host_id int) {
 					defer hostwaitgroup.Done()
-					hostname := fmt.Sprintf("%s_%d", "redhat.bosoton.nfv", host_id)
+					hostname := fmt.Sprintf("%s_%d", "redhat.boston.nfv", host_id)
 					incomingType := incoming.NewInComing(incoming.COLLECTD)
 					go cacheServer.GenrateSampleData(hostname, *fPlugins, incomingType)
 				}(hosts)

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,7 @@ func BenchmarkWithSampleData(b *testing.B) {
 	cacheServer = cacheutil.NewCacheServer()
 	incomingType := incoming.NewInComing(incoming.COLLECTD)
 	for hostid := 0; hostid < b.N; hostid++ {
-		var hostname = fmt.Sprintf("%s_%d", "redhat.bosoton.nfv", hostid)
+		var hostname = fmt.Sprintf("%s_%d", "redhat.boston.nfv", hostid)
 		go cacheServer.GenrateSampleData(hostname, 100, incomingType)
 	}
 
@@ -44,7 +44,7 @@ func TestPut(t *testing.T) {
 				//100o hosts
 				//pluginChannel := make(chan cacheutil.Collectd)
 				//for each host make it on go routine
-				var hostname = fmt.Sprintf("%s_%d", "redhat.bosoton.nfv", host_id)
+				var hostname = fmt.Sprintf("%s_%d", "redhat.boston.nfv", host_id)
 				//fmt.Printf("Iteration %d hostname %s\n",times,hostname)
 
 				collectd := incoming.NewInComing(incoming.COLLECTD)


### PR DESCRIPTION
Spell corrections.

Remove cpustats and go stats inclusion by default in scrape.