### PR TITLE
[enhance] Update metrics sample pod to use ConfigMap

### DIFF
--- a/ansible/roles/prometheus-operator/files/smartagent/metrics/metrics-config.yaml
+++ b/ansible/roles/prometheus-operator/files/smartagent/metrics/metrics-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-config
+data:
+  sa.metrics.config.json: |+
+    {
+            "Exporterhost": "0.0.0.0",
+            "Exporterport": 8081,
+            "Hosts": "10",
+            "Plugins": "100",
+            "UseSample": true,
+            "Sample": {
+                    "HostCount": 10,
+                    "PluginCount": 100,
+                    "DataCount": -1
+            }
+    }

--- a/ansible/roles/prometheus-operator/files/smartagent/metrics/metrics-deployment.yaml
+++ b/ansible/roles/prometheus-operator/files/smartagent/metrics/metrics-deployment.yaml
@@ -14,10 +14,10 @@ spec:
         runAsUser: 65534
       containers:
       - name: metrics
-        image: docker.io/nfvpe/metrics:latest
-        ports:
-        - name: metrics
-          containerPort: 8081
+        image: docker.io/nfvpe/sa_metrics:latest
+        volumeMounts:
+        - name: metrics-config
+          mountPath: /config
         resources:
           requests:
             memory: 100Mi
@@ -25,3 +25,12 @@ spec:
           limits:
             memory: 200Mi
             cpu: 200m
+        args: ["-config=/config/sa.metrics.config.json"]
+        ports:
+        - name: metrics
+          containerPort: 8081
+      volumes:
+      - name: metrics-config
+        configMap:
+          name: metrics-config
+


### PR DESCRIPTION
Convert the metrics sample pod to using a ConfigMap for the configuration
which will be useful soon when we want to connect it to the QDR. Right now
it simply updates to the new sa_metrics container, and moves from using
an embedded set of command flags in the container, to externalizing
them in the kubernetes manifests.

Adds the -config flag to the Deployment for metrics, and points at a
ConfigMap that is made available via a volumeMount.